### PR TITLE
Cope with bad querystring input when calculating pagination

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -510,7 +510,7 @@ class Pagination
 		{
 			if ( ! ctype_digit((string) $this->config['uri_segment']))
 			{
-				$this->config['calculated_page'] = \Input::get($this->config['uri_segment'], null);
+				$this->config['calculated_page'] = $this->_validate('current_page', \Input::get($this->config['uri_segment'], null));
 			}
 			else
 			{
@@ -708,7 +708,7 @@ class Pagination
 			case 'total_pages':
 			case 'num_links':
 				// make sure it's an integer
-				if ($value != intval($value))
+				if ($value !== intval($value))
 				{
 					$value = 1;
 				}


### PR DESCRIPTION
`?page=3%27A=0` generates avoidable errors because `\Input::get()` is trusted to return an appropriate value for the pagination.

Using the already created `_validate` method does not resolve the situation because the crucial comparison is not type-accurate and lets bad strings through.

![image](https://user-images.githubusercontent.com/1619102/64541173-57ab5480-d319-11e9-94c7-9959d4282b31.png)
