### PR TITLE
fix valid integer checks

### DIFF
--- a/classes/pagination.php
+++ b/classes/pagination.php
@@ -679,12 +679,7 @@ class Pagination
 			case 'offset':
 			case 'total_items':
 				// make sure it's an integer
-				if ($value != intval($value))
-				{
-					$value = 0;
-				}
-				// and that it's within bounds
-				$value = max(0, $value);
+				$value = max(0, (int) $value);
 			break;
 
 			// integer or string
@@ -692,12 +687,7 @@ class Pagination
 				if (is_numeric($value))
 				{
 					// make sure it's an integer
-					if ($value != intval($value))
-					{
-						$value = 1;
-					}
-					// and that it's within bounds
-					$value = max(1, $value);
+					$value = max(1, (int) $value);
 				}
 			break;
 
@@ -708,12 +698,7 @@ class Pagination
 			case 'total_pages':
 			case 'num_links':
 				// make sure it's an integer
-				if ($value !== intval($value))
-				{
-					$value = 1;
-				}
-				// and that it's within bounds
-				$value = max(1, $value);
+				$value = max(1, (int) $value);
 			break;
 
 			// validate booleans


### PR DESCRIPTION
#5 introduces a bug which results in only being able to see page 1 of any pagination.

It works better if one uses integer casting to remove unwanted non-numeric characters from string.

The behaviour change is that (before #5) broken pagination would always put you on the first page, this code means it depends on the value that is in the broken pagination.

![image](https://user-images.githubusercontent.com/1619102/64598631-f8e4ea00-d3af-11e9-83c5-7fb616b61fdb.png)
