### PR TITLE
don't call exit when calling Response::redirect

### DIFF
--- a/classes/response.php
+++ b/classes/response.php
@@ -102,8 +102,7 @@ class Response
 	}
 
 	/**
-	 * Redirects to another uri/url.  Sets the redirect header,
-	 * sends the headers and exits.  Can redirect via a Location header
+	 * Redirects to another uri/url. Can redirect via a Location header
 	 * or using a refresh header.
 	 *
 	 * The refresh header works better on certain servers like IIS.
@@ -138,13 +137,8 @@ class Response
 		{
 			$response->set_header('Refresh', '0;url='.$url);
 		}
-		else
-		{
-			return;
-		}
 
-		$response->send(true);
-		exit;
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
another QoL change
give the Response back to the application to decide how it wants to handle this
calling exit is really unfriendly to automated testing